### PR TITLE
Fix code scanning alert no. 12: DOM text reinterpreted as HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,15 @@
 
     <script> // before loading / importing
         var scriptsLoaded = []; // scripts below use this variable so its needs to be defined before the scripts run.
+        
+        function escapeHtml(unsafe) {
+            return unsafe
+                .replace(/&/g, "&amp;")
+                .replace(/</g, "&lt;")
+                .replace(/>/g, "&gt;")
+                .replace(/"/g, "&quot;")
+                .replace(/'/g, "&#039;");
+        }
     </script>
 
     <!-- scripts -->
@@ -429,7 +438,7 @@
 
                 // - for removing snippet from snippets (local storage variable) -
         
-                document.getElementById("snippet-editor").innerHTML = `<br><h4>snippet ${snippetName} was deleted...<h4>`;
+                document.getElementById("snippet-editor").innerHTML = `<br><h4>snippet ${escapeHtml(snippetName)} was deleted...<h4>`;
                 setTimeout(function() {
                     document.getElementById("snippet-editor").innerHTML = "<br><h4>select or create a snippet and it will appear here!<h4>";
                 }, 2600);
@@ -447,7 +456,7 @@
                 }
                 
                 var snippetName = document.getElementById("loadedSnippetName").innerText;
-                document.getElementById("snippet-editor").innerHTML = `<br><h4>closed snippet ${snippetName}<h4>`;
+                document.getElementById("snippet-editor").innerHTML = `<br><h4>closed snippet ${escapeHtml(snippetName)}<h4>`;
                 setTimeout(function() {
                     document.getElementById("snippet-editor").innerHTML = "<br><h4>select or create a snippet and it will appear here!<h4>";
                 }, 2600);
@@ -457,6 +466,7 @@
                 }
             }
         }
+
 
         function isValidSnippetName(name) {
             const invalidChars = /[<>:"/\\|?*\s]/; 


### PR DESCRIPTION
Fixes [https://github.com/Kaleb1583/editor/security/code-scanning/12](https://github.com/Kaleb1583/editor/security/code-scanning/12)

To fix the problem, we need to ensure that any text extracted from the DOM and reinserted as HTML is properly escaped to prevent XSS attacks. The best way to fix this is to use a function that escapes HTML special characters before inserting the text into the HTML.

- Create a function to escape HTML special characters.
- Use this function to sanitize the `snippetName` before inserting it into the HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
