### PR TITLE
Fix code scanning alert no. 9: DOM text reinterpreted as HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,18 +316,34 @@
                     if(selectedSnippetValue == "") { // (!(selectedSnippetValue.includes("<html>")) && !(selectedSnippetValue.includes("</html>")))
                         console.log(`${selectedSnippet} is an empty snippet`)
                         var emptySnippetText = document.createElement("b");
-                        emptySnippetText.innerHTML = `<span onclick='getASnippet("${selectedSnippet}")'>${selectedSnippet}.html (Empty)</span>&nbsp;&nbsp;|&nbsp;&nbsp;<span onclick='deleteASnippet("${selectedSnippet}")' style='color: red;'>[Delete]</span><br>`;
-                        //emptySnippetText.setAttribute("onclick",`getASnippet('${selectedSnippet}')`); 
+                        var emptySnippetSpan = document.createElement("span");
+                        emptySnippetSpan.textContent = `${selectedSnippet}.html (Empty)`;
+                        emptySnippetSpan.setAttribute("onclick", `getASnippet("${selectedSnippet}")`);
+                        var deleteSpan = document.createElement("span");
+                        deleteSpan.textContent = "[Delete]";
+                        deleteSpan.setAttribute("onclick", `deleteASnippet("${selectedSnippet}")`);
+                        deleteSpan.style.color = "red";
+                        emptySnippetText.appendChild(emptySnippetSpan);
+                        emptySnippetText.appendChild(document.createTextNode(" | "));
+                        emptySnippetText.appendChild(deleteSpan);
+                        emptySnippetText.appendChild(document.createElement("br"));
                         elements.push(emptySnippetText);
                     } else {
                         console.log(`got snippet '${selectedSnippet}'.`)
                         var snippetText = document.createElement("b");
-                        if(selectedSnippet == "Example") { 
-                            snippetText.innerHTML = `<span onclick='getASnippet("${selectedSnippet}")'>${selectedSnippet}</span><br>`;
-                        } else {
-                            snippetText.innerHTML = `<span onclick='getASnippet("${selectedSnippet}")'>${selectedSnippet}.html</span>&nbsp;&nbsp;|&nbsp;&nbsp;<span onclick='deleteASnippet("${selectedSnippet}")' style='color: red;'>[Delete]</span><br>`;
+                        var snippetSpan = document.createElement("span");
+                        snippetSpan.textContent = selectedSnippet;
+                        snippetSpan.setAttribute("onclick", `getASnippet("${selectedSnippet}")`);
+                        snippetText.appendChild(snippetSpan);
+                        if(selectedSnippet != "Example") {
+                            var deleteSpan = document.createElement("span");
+                            deleteSpan.textContent = "[Delete]";
+                            deleteSpan.setAttribute("onclick", `deleteASnippet("${selectedSnippet}")`);
+                            deleteSpan.style.color = "red";
+                            snippetText.appendChild(document.createTextNode(" | "));
+                            snippetText.appendChild(deleteSpan);
                         }
-                        //snippetText.setAttribute("onclick",`getASnippet('${selectedSnippet}')`); 
+                        snippetText.appendChild(document.createElement("br"));
                         elements.push(snippetText);
                     }
 


### PR DESCRIPTION
Fixes [https://github.com/Kaleb1583/editor/security/code-scanning/9](https://github.com/Kaleb1583/editor/security/code-scanning/9)

To fix the problem, we need to ensure that any user-controlled data inserted into the HTML is properly escaped to prevent XSS attacks. The best way to fix this issue is to use textContent or create text nodes instead of using innerHTML. This will ensure that any special characters in the user input are treated as text rather than HTML.

Specifically, we will:
1. Replace the use of `innerHTML` with `textContent` for the `selectedSnippet` variable.
2. Create separate elements for the clickable parts and append them to the parent element to avoid using `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
